### PR TITLE
openwrt requires explicitly linking to argp

### DIFF
--- a/packages/serval-crypto/Makefile
+++ b/packages/serval-crypto/Makefile
@@ -31,7 +31,7 @@ define Package/serval-crypto/description
 endef
 
 TARGET_CFLAGS += $(TLS_CFLAGS) -I$(BUILD_DIR)/serval-dna-$(SERVAL_VERSION) -I$(BUILD_DIR)/serval-dna-$(SERVAL_VERSION)/nacl/include -O3
-TARGET_LDFLAGS += -L$(BUILD_DIR)/serval-dna-$(SERVAL_VERSION)/ -lservald
+TARGET_LDFLAGS += -L$(BUILD_DIR)/serval-dna-$(SERVAL_VERSION)/ -lservald -largp
 
 define Package/serval-crypto/install
 	$(INSTALL_DIR) $(1)/usr/sbin


### PR DESCRIPTION
needed for https://github.com/opentechinstitute/serval-crypto/pull/4
