### PR TITLE
Add argp-standalone dependency to serval-crypto Makefile.

### DIFF
--- a/packages/serval-crypto/Makefile
+++ b/packages/serval-crypto/Makefile
@@ -21,7 +21,7 @@ define Package/serval-crypto
   CATEGORY:=Commotion
   TITLE:=Serval signing and verification
   MAINTAINER:=Open Technology Institute
-  DEPENDS:=+serval-dna
+  DEPENDS:=+serval-dna +argp-standalone
 endef
 
 define Package/serval-crypto/description


### PR DESCRIPTION
Add explicit argp dependency to serval-crypto package, to ensure argp-standalone builds first and linking succeeds.
