### PR TITLE
Increment release of bigboard send, to pull fixes in to new build.

### DIFF
--- a/packages/commotion-bigboard-send/Makefile
+++ b/packages/commotion-bigboard-send/Makefile
@@ -7,7 +7,7 @@ THEME_NAME:=commotion
 THEME_TITLE:=Commotion
 
 PKG_NAME:=$(MODULE_NAME)
-PKG_VERSION:=release-0.1
+PKG_VERSION:=release-0.1.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
This should allow nodes to communicate with the public dashboard server.
