### PR TITLE
netifd commotion.sh script needs to be installed as executable file

### DIFF
--- a/packages/commotiond/Makefile
+++ b/packages/commotiond/Makefile
@@ -69,7 +69,7 @@ define Package/commotiond/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/openwrt/etc/config/commotiond $(1)/etc/config
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/etc/init.d/commotiond $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/lib/netifd/commotion.dhcp.script $(1)/lib/netifd
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/openwrt/lib/netifd/proto/commotion.sh $(1)/lib/netifd/proto
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/openwrt/lib/netifd/proto/commotion.sh $(1)/lib/netifd/proto
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/openwrt/lib/functions/commotion.sh $(1)/lib/functions
 	$(CP) $(PKG_BUILD_DIR)/openwrt/usr/share/commotion/patches/* $(1)/usr/share/commotion/patches/
 	$(CP) $(PKG_BUILD_DIR)/files/profiles.d/* $(1)/etc/commotion/profiles.d/


### PR DESCRIPTION
...otherwise it cannot be run, and newly-flashed nodes are left without valid IPs.  This bug was obscured by the existence of the 192.168.1.20 alias, but now that the alias is gone, newly-flashed nodes cannot be accessed at all.  
