### PR TITLE
added lua-uri to commotion_helpers dependences

### DIFF
--- a/packages/luci-commotion/Makefile
+++ b/packages/luci-commotion/Makefile
@@ -100,6 +100,7 @@ define Package/commotion-lua
   SECTION:=commotion
   CATEGORY:=Commotion
   SUBMENU:=Libraries
+  DEPENDS:=+lua-uri
   TITLE:=Commotion-Lua
   URL:=https://commotionwireless.net/
 endef


### PR DESCRIPTION
latest commotion_helpers fix requires lua_uri dependency. see https://github.com/opentechinstitute/luci-commotion/commit/f7e5085510de2ab5779bd6d2d3c38d006fa3817c

<!---
@huboard:{"order":54.0}
-->
