### PR TITLE
changed serval-dna version from batphone-release-0.91 to commotion-wireless

### DIFF
--- a/packages/olsrd/Makefile
+++ b/packages/olsrd/Makefile
@@ -7,7 +7,7 @@
 
 include $(TOPDIR)/rules.mk
 
-SERVAL_VERSION:=batphone-release-0.91
+SERVAL_VERSION:=commotion-wireless
 COMMOTION_VERSION:=commotion
 
 PKG_NAME:=olsrd

--- a/packages/serval-crypto/Makefile
+++ b/packages/serval-crypto/Makefile
@@ -1,6 +1,6 @@
 include $(TOPDIR)/rules.mk
 
-SERVAL_VERSION:=batphone-release-0.91
+SERVAL_VERSION:=commotion-wireless
 
 PKG_NAME:=serval-crypto
 PKG_RELEASE:=1

--- a/packages/serval-dna/Makefile
+++ b/packages/serval-dna/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=serval-dna
-PKG_VERSION:=batphone-release-0.91
+PKG_VERSION:=commotion-wireless
 PKG_RELEASE=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
To test:

build two nodes with the image, and ensure app advertising works and that one node can ping the other using servald.

Also enable olsrd-mdp and ensure the nodes have routes to each other.

Also also, check the memory usage of serval-dna. The memory leak fix probably won't make a difference, but it's worth checking.

If you would like images to test, I have them already built, just come find me.

<!---
@huboard:{"order":20.75}
-->
