### PR TITLE
hack to download olsrd tarball with more identifying filename

### DIFF
--- a/packages/olsrd/Makefile
+++ b/packages/olsrd/Makefile
@@ -13,10 +13,10 @@ PKG_NAME:=olsrd
 PKG_VERSION:=0.6.5.4-$(COMMOTION_VERSION)
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://github.com/opentechinstitute/olsrd/archive
+PKG_SOURCE_URL:=https://github.com/opentechinstitute/olsrd/archive/$(COMMOTION_VERSION).tar.gz?
 PKG_SOURCE_VERSION:=$(COMMOTION_VERSION)
 
-PKG_SOURCE:=$(PKG_SOURCE_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_SOURCE_VERSION)
 
 PKG_BUILD_PARALLEL:=1


### PR DESCRIPTION
currently, due to Github's archive download URLs, olsrd is being downloaded as `<branch name>.tar.gz`, which is hardly identifying. It will help our build script if it is downloaded as `olsrd-0.6.5.4-<branch name>.tar.gz`, so we can better remove it from the dl directory when we want to pull in a fresh version.

to test, build olsrd for openwrt and make sure it succeeds. There should be a file in the `dl` folder called `olsrd-0.6.5.4-commotion.tar.gz`.
