### PR TITLE
Removed untranslated French package for R1.1 which does not have correct strings.

### DIFF
--- a/packages/luci-i18n-commotion/Makefile
+++ b/packages/luci-i18n-commotion/Makefile
@@ -61,7 +61,7 @@ define prep-package
 endef
 
 #languages to offer
-$(eval $(call prep-package,French,french,fr))
+#$(eval $(call prep-package,French,french,fr))
 $(eval $(call prep-package,Spanish,spanish,es))
 
 #actually build packages if added to the CO_BUILD_PACKAGES and checked in menuconfig


### PR DESCRIPTION
Removed french translation package since it does not have up to date luci translations for R1

@jheretic This will bring R1 translations up to date and ready for testing.

To test:
- Run the commotion setup script
- cd  into openwrt
- run make menuconfig
- make sure that the translation menu only contains the spanish translations
