### PR TITLE
Wrong path on po2lmo utility

### DIFF
--- a/packages/luci-i18n-commotion/Makefile
+++ b/packages/luci-i18n-commotion/Makefile
@@ -30,7 +30,7 @@ endef
 #Get and make the po2lmo po->lmo script
 define Build/Prepare
 	$(call Build/Prepare/Default,)
-	$(SVN) co http://svn.luci.subsignal.org/luci/branches/luci-0.11/modules/base/ $(PKG_BUILD_DIR)/po2lmo/.
+	$(SVN) co http://svn.luci.subsignal.org/luci/branches/luci-0.11/libs/web/ $(PKG_BUILD_DIR)/po2lmo/.
 	$(MKDIR) $(PKG_BUILD_DIR)/lang
 	$(MAKE_po2lmo)
 endef


### PR DESCRIPTION
Fixes #53 

To test:
1. Build commotion-router with an additional language installed. The build should complete without fatal errors.
2. Flash router and switch to alternate language. Translations should work.

<!---
@huboard:{"order":22.5}
-->
