### PR TITLE
Fixed assets path in luci-commotion-apps

### DIFF
--- a/packages/luci-commotion/Makefile
+++ b/packages/luci-commotion/Makefile
@@ -78,7 +78,9 @@ define Package/luci-mod-commotion/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/luasrc/view/cbi/commotion/addMesh.htm $(1)/usr/lib/lua/luci/view/cbi/commotion
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/luasrc/view/cbi/commotion/delegator.htm $(1)/usr/lib/lua/luci/view/cbi/commotion
 	$(INSTALL_DIR) $(1)/www/luci-static/resources/
-	$(CP) $(PKG_BUILD_DIR)/htdocs/luci-static/* $(1)/www/luci-static/ 2>/dev/null || true
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/htdocs/luci-static/commotion_index.html $(1)/www/luci-static/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/htdocs/luci-static/resources/OSMLatLon.htm $(1)/www/luci-static/resources/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/htdocs/luci-static/resources/osm.js $(1)/www/luci-static/resources/
 endef
 
 define Package/luci-mod-commotion/postinst
@@ -159,7 +161,7 @@ endef
 
 define Package/luci-commotion-apps/install
 	$(INSTALL_DIR) $(1)/www/luci-static/commotion
-	$(CP) $(PKG_BUILD_DIR)/luci-static/apps/* $(1)/www/luci-static/commotion/ || true
+	$(CP) $(PKG_BUILD_DIR)/htdocs/luci-static/apps/* $(1)/www/luci-static/commotion/ || true
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view/commotion
 	$(CP) $(PKG_BUILD_DIR)/luasrc/view/commotion/apps_* $(1)/usr/lib/lua/luci/view/commotion/ || true
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view/themes/commotion


### PR DESCRIPTION
Apps will not be advertised correctly until #44 is resolved.

To test:
1. SSH/telnet to the node and type `ls /www/luci-static`. You should not see an apps directory.
2. Type `opkg files luci-commotion-apps`. You should get the following:
/www/luci-static/commotion/code.png
/www/luci-static/commotion/equals.png
/www/luci-static/commotion/radio.png
/www/luci-static/commotion/apps_form.js
/www/luci-static/commotion/chat.png
/www/luci-static/commotion/audio.png
/www/luci-static/commotion/apps.js
/usr/lib/lua/luci/controller/commotion/apps_controller.lua
/usr/lib/lua/luci/view/commotion/apps_view.htm
/www/luci-static/commotion/x.png
/usr/lib/lua/luci/model/cbi/commotion/app_settings.lua
/usr/lib/lua/luci/view/themes/commotion/apps_apps.htm
/usr/lib/lua/luci/view/commotion/apps_settings.htm
/www/luci-static/commotion/write.png
/www/luci-static/commotion/email.png
/www/luci-static/commotion/commotion-faded2.png
/www/luci-static/commotion/calendar.png
/www/luci-static/commotion/internet.png
/usr/lib/lua/luci/view/commotion/apps_display.htm
/usr/lib/lua/luci/view/themes/commotion/apps_categories.htm
/www/luci-static/commotion/check.png
/www/luci-static/commotion/commotion-faded.png
/www/luci-static/commotion/downloads.png
/usr/lib/lua/luci/view/commotion/apps_form.htm
/www/luci-static/commotion/apps.css
/www/luci-static/commotion/bann.png
/www/luci-static/commotion/admin_apps.js
/www/luci-static/commotion/photo.png
/www/luci-static/commotion/patternizer.min.js
/usr/lib/lua/luci/view/commotion/apps_admin_display.htm

Fixes #55 

<!---
@huboard:{"order":37.0}
-->
