### PR TITLE
include nds_config.lua script needed to apply nodogsplash config changes...

### DIFF
--- a/packages/luci-commotion/Makefile
+++ b/packages/luci-commotion/Makefile
@@ -188,6 +188,8 @@ define Package/luci-commotion-splash/description
 endef
 
 define Package/luci-commotion-splash/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/commotion
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/luasrc/commotion/nds_config.lua $(1)/usr/lib/lua/luci/commotion
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller/commotion-splash
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/luasrc/controller/commotion-splash/splash.lua $(1)/usr/lib/lua/luci/controller/commotion-splash
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model/cbi/commotion-splash


### PR DESCRIPTION
... after UCI change

to test, go to advanced->services->captive portal, and check the "redirect" box, and add a URL to redirect to. Apply changes and visit a non-HTTPS website. After getting the captive portal, click on the "Internet" button, and you should be redirected to the page you set previously.
