### PR TITLE
include /etc/config/serval in luci-mod-commotion

### DIFF
--- a/packages/luci-commotion/Makefile
+++ b/packages/luci-commotion/Makefile
@@ -44,6 +44,7 @@ define Package/luci-mod-commotion/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/uci-defaults/luci-mod-commotion $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/config/setup_wizard $(1)/etc/config
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/files/etc/config/serval $(1)/etc/config
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/hostname $(1)/etc/init.d
 	$(INSTALL_DIR) $(1)/usr/share/commotion/files


### PR DESCRIPTION
without this file, downloading SMK file with give LuCI error.

to test, create a SMK on a node, then attempt to download it.
