### PR TITLE
add dhcp-relay option to dnsmasq

### DIFF
--- a/packages/dnsmasq/Makefile
+++ b/packages/dnsmasq/Makefile
@@ -75,7 +75,7 @@ endef
 Package/dnsmasq-dhcpv6/conffiles = $(Package/dnsmasq/conffiles)
 Package/dnsmasq-full/conffiles = $(Package/dnsmasq/conffiles)
 
-TARGET_CFLAGS += -ffunction-sections -fdata-sections
+TARGET_CFLAGS += -ffunction-sections -fdata-sections -fno-merge-constants
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 COPTS = $(if $(CONFIG_IPV6),,-DNO_IPV6)

--- a/packages/dnsmasq/files/dnsmasq.init
+++ b/packages/dnsmasq/files/dnsmasq.init
@@ -144,6 +144,7 @@ dnsmasq() {
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
 	append_parm "$cfg" "local_ttl" "--local-ttl"
+	append_parm "$cfg" "dhcp_relay" "--dhcp-relay"
 
 	config_get DOMAIN "$cfg" domain
 


### PR DESCRIPTION
To test, first run `dnsmasq --help` on the node and make sure the `dhcp-relay` option is present.

Then add the following line to the `dnsmasq` section of /etc/config/dhcp:
`option dhcp_relay '0.0.0.0,1.2.3.4'`
where `1.2.3.4` is the IP address of a reachable server running a DHCP daemon.

Next, set `ignore "0"` to `ignore "1"` in the `dhcp` section of the same config. Restart dnsmasq and ensure that connecting clients get a DHCP lease from the server and not the node.